### PR TITLE
Removed trailing comma at end of env declaration

### DIFF
--- a/data-mapper-logstash/docker-compose.yml
+++ b/data-mapper-logstash/docker-compose.yml
@@ -10,7 +10,7 @@ services:
       retries: 5
       start_period: 30s
     environment:
-      ES_ELASTIC: ${ES_ELASTIC},
+      ES_ELASTIC: ${ES_ELASTIC}
       LS_JAVA_OPTS: ${LS_JAVA_OPTS:--Xmx2g -Xms2g}
     configs:
       - target: /usr/share/logstash/config/log4j2.properties

--- a/data-mapper-logstash/pipeline/fhir-extractor.logstash.conf
+++ b/data-mapper-logstash/pipeline/fhir-extractor.logstash.conf
@@ -61,7 +61,7 @@ output {
       action => "update"
       doc_as_upsert => true
       user => "elastic"
-      password => "dev_password_only"
+      password => "${ES_ELASTIC}"
     }
   }
 
@@ -73,7 +73,7 @@ output {
       action => "delete"
       doc_as_upsert => true
       user => "elastic"
-      password => "dev_password_only"
+      password => "${ES_ELASTIC}"
     }
   }
 }


### PR DESCRIPTION
To prevent , from being unintentionally appended to the end of the password