### PR TITLE
Added functionality to get-cli to split downloads

### DIFF
--- a/get-cli.sh
+++ b/get-cli.sh
@@ -8,19 +8,19 @@ case ${option} in
         echo "Downloading linux binary version: ${cliVersion}"
         curl -L https://github.com/openhie/package-starter-kit/releases/download/$cliVersion/gocli-linux -o platform-linux
         chmod +x ./platform-linux
-        exit 1
+        exit 0
       ;; 
    macos)
         echo "Downloading macos binary version: ${cliVersion}"
         curl -L https://github.com/openhie/package-starter-kit/releases/download/$cliVersion/gocli-macos -o platform-macos
         chmod +x ./platform-macos
-        exit 1
+        exit 0
       ;; 
    windows)
         echo "Downloading windows binary version: ${cliVersion}"
         curl -L https://github.com/openhie/package-starter-kit/releases/download/$cliVersion/gocli.exe -o platform.exe
         chmod +x ./platform.exe
-        exit 1
+        exit 0
       ;;
     all)
         echo "Downloading all binaries, version: ${cliVersion}"
@@ -30,9 +30,9 @@ case ${option} in
         chmod +x ./platform-linux
         chmod +x ./platform-macos
         chmod +x ./platform.exe
-        exit 1
+        exit 0
       ;;
     --help)
         echo "Usage: get-cli.sh [linux|macos|windows|all] {cliVersion}"
-        exit 1
+        exit 0
 esac


### PR DESCRIPTION
To ensure the user of the script can download only the binary that they require. Also to allow the version to be specified as a parameter to the script