### PR TITLE
PLAT-301_Fix installation of jq

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,4 +8,4 @@ RUN chmod +x /usr/bin/yq
 
 # Install jq
 
-RUN apt-get install jq -y
+RUN apt-get install jq -y 1>/dev/null


### PR DESCRIPTION
Turns out that jq was not installed correctly causing the missing config of logstash