### PR TITLE
Update Jsreport ports syntax to work on localhost

### DIFF
--- a/dashboard-visualiser-jsreport/docker-compose.dev.yml
+++ b/dashboard-visualiser-jsreport/docker-compose.dev.yml
@@ -3,4 +3,6 @@ version: '3.9'
 services:
   dashboard-visualiser-jsreport:
     ports:
-      - 5488:5488
+      - target: 5488
+        published: 5488
+        mode: host


### PR DESCRIPTION
Jsreport now works only on 127.0.0.1
This PR will allow Jsreport to work on both localhost and 127.0.01