### PR TITLE
PLAT-274 Add a check to not rerun nginx if it is already up

### DIFF
--- a/reverse-proxy-nginx/swarm.sh
+++ b/reverse-proxy-nginx/swarm.sh
@@ -22,6 +22,10 @@ main() {
       echo "Not starting reverse proxy as we are running DEV mode"
       exit 0
     fi
+    if [[ $(docker service ps instant_reverse-proxy-nginx --format '{{.CurrentState}}') == *"Running"* ]]; then
+      echo "Skipping reverse proxy reload as it is already up"
+      exit 0
+    fi
 
     docker stack deploy -c "${COMPOSE_FILE_PATH}"/docker-compose.yml instant
 


### PR DESCRIPTION
I've done a remote deploy to test that this fix works, and it does. I see possible objections to this method though, would be nice to get an approval from @rcrichton .

We could also add this method to elastic search, since quite a few packages are also dependent on it, and a reload is not always necessary.