### PR TITLE
Rolling updates for logstash

### DIFF
--- a/data-mapper-logstash/swarm.sh
+++ b/data-mapper-logstash/swarm.sh
@@ -75,8 +75,7 @@ if [[ "${ACTION}" == "init" ]] || [[ "${ACTION}" == "up" ]]; then
 
   config::remove_stale_service_configs "${COMPOSE_FILE_PATH}/docker-compose.yml" "logstash"
 
-  # shellcheck disable=SC2046
-  docker config rm $(docker config ls -q) &>/dev/null
+  docker::prune_configs logstash
 
   log info "Done"
 elif [[ "${ACTION}" == "down" ]]; then

--- a/utils/docker-utils.sh
+++ b/utils/docker-utils.sh
@@ -114,3 +114,15 @@ docker::try_remove_volume() {
     done
     overwrite "Waiting for volume ${VOLUME_NAME} to be removed... Done"
 }
+
+# Prunes configs based on a label
+#
+# Arguments:
+# - $1 : config label, e.g. "logstash"
+#
+docker::prune_configs() {
+    local -r CONFIG_LABEL=${1:?"FATAL: remove_configs_by_label CONFIG_LABEL not provided"}
+
+    # shellcheck disable=SC2046
+    docker config rm $(docker config ls -qf label=name="$CONFIG_LABEL") &>/dev/null
+}


### PR DESCRIPTION
The `up` command can be used as-is for updating logstash pipelines, the only thing that this commit does is ensure that unused configs after an update are removed.