### PR TITLE
Limit hapi fhir server to one replica per node

### DIFF
--- a/fhir-datastore-hapi-fhir/docker-compose.yml
+++ b/fhir-datastore-hapi-fhir/docker-compose.yml
@@ -16,6 +16,8 @@ services:
       - CATALINA_OPTS=-Xmx2g
     deploy:
       replicas: ${HAPI_FHIR_INSTANCES}
+      placement:
+        max_replicas_per_node: 1
       resources:
         limits:
           cpus: ${HAPI_FHIR_CPU_LIMIT:-0.8}


### PR DESCRIPTION
To avoid multiple replicas starting up on a single node.