### PR TITLE
Added bind mount for jempi-async-receiver

### DIFF
--- a/client-registry-jempi/docker-compose.combined.yml
+++ b/client-registry-jempi/docker-compose.combined.yml
@@ -3,6 +3,8 @@ version: '3.9'
 services:
   jempi-async-receiver:
     image: jembi/jempi-async-receiver:${JEMPI_AJEMPI_SYNC_RECEIVER_IMAGE_TAG}
+    volumes:
+      - /jempi-csv-data/csv:/app/csv
     deploy:
       replicas: 1
       resources:


### PR DESCRIPTION
Without the bind mount, the async receiver of client-registry-jempi would fail to stand up