### PR TITLE
PLAT-621 kafdrop restart connection with Kafka

### DIFF
--- a/message-bus-kafka/docker-compose.kafka.yml
+++ b/message-bus-kafka/docker-compose.kafka.yml
@@ -3,6 +3,7 @@ version: '3.9'
 services:
   kafka:
     image: bitnami/kafka:3.1.0
+    hostname: kafka
     environment:
       - KAFKA_CFG_ZOOKEEPER_CONNECT=zookeeper-1:2181
       - ALLOW_PLAINTEXT_LISTENER=yes


### PR DESCRIPTION
I was able to implement a healthcheck in kafdrop, but the healthcheck will do nothing in case Kafka is down for these reasons:
* it is already built in in, kafdrop will fail at the start if kafka is not up [we need that]
* if kafka was running and then for a certain reason fail down [not in the start], kafdrop will keep throwing an exception : unknowHostException without exiting [that's a problem]
and to test that I scaled down kafka, and bring it back but kafdrop still down [as you can see there is a random id tof the host rying to connect to in the logs]
![image](https://user-images.githubusercontent.com/48720958/205032713-376dd94b-9ac5-4fff-b356-74b5438c10cd.png)

The solution was to add a hostname in the docker-compose of kafka, and it solved the issue, when I bring down Kafka and bring it up again, kafdrop will start connecting to kafka again
![image](https://user-images.githubusercontent.com/48720958/205032780-92a93978-4677-432f-bc30-9499169f1c0d.png)
