### PR TITLE
fix: prevent HAPI from doing WRITE on readonly replicas

### DIFF
--- a/fhir-datastore-hapi-fhir/docker-compose.yml
+++ b/fhir-datastore-hapi-fhir/docker-compose.yml
@@ -4,7 +4,7 @@ services:
   hapi-fhir:
     image: jembi/hapi:v5.7.0-wget
     environment:
-      - spring.datasource.url=jdbc:postgresql://${POSTGRES_REPLICA_SET}/hapi
+      - spring.datasource.url=jdbc:postgresql://${POSTGRES_REPLICA_SET}/hapi?targetServerType=primary
       - spring.datasource.username=admin
       - spring.datasource.password=instant101
       - spring.datasource.driverClassName=org.postgresql.Driver


### PR DESCRIPTION
Given the investigation conducted in https://jembiprojects.jira.com/browse/PLAT-603

The priority would be to prevent HAPI FHIR from performing write operation on a readonly/standby database.

Ticket : https://jembiprojects.jira.com/browse/PLAT-628

## How to test

1. Start a cluster
2. Perform write requests to HAPI FHIR using postman
3. Cut-off the network for node-1
4. Inspect the logs

Note that there will be failing requests while the new primary is elected.