### PR TITLE
PLAT-606 Pull images before deploy if they don't exist

### DIFF
--- a/utils/docker-utils.sh
+++ b/utils/docker-utils.sh
@@ -196,7 +196,7 @@ docker::check_images_existence() {
         if [[ -z $(docker image inspect "$image_name" --format "{{.Id}}" 2>/dev/null) ]]; then
             log info "The image $image_name is not found, Pulling from docker..."
             try \
-                "docker pull $image_name" \
+                "docker pull $image_name &>/dev/null" \
                 throw \
                 "An error occured while pulling the image $image_name"
 

--- a/utils/docker-utils.sh
+++ b/utils/docker-utils.sh
@@ -192,11 +192,13 @@ docker::check_images_existence() {
         exit 1
     fi
 
+    local timeout_pull_image
+    timeout_pull_image=300
     for image_name in "$@"; do
         if [[ -z $(docker image inspect "$image_name" --format "{{.Id}}" 2>/dev/null) ]]; then
             log info "The image $image_name is not found, Pulling from docker..."
             try \
-                "docker pull $image_name &>/dev/null" \
+                "timeout $timeout_pull_image docker pull $image_name 1>/dev/null" \
                 throw \
                 "An error occured while pulling the image $image_name"
 

--- a/utils/docker-utils.sh
+++ b/utils/docker-utils.sh
@@ -192,14 +192,15 @@ docker::check_images_existence() {
         exit 1
     fi
 
-    for i in "$@"; do
-        if [[ -z $(docker image inspect "$i" --format "{{.Id}}" 2>/dev/null) ]]; then
-            log info "The image $i is not found, Pulling from docker..."
+    for image_name in "$@"; do
+        if [[ -z $(docker image inspect "$image_name" --format "{{.Id}}" 2>/dev/null) ]]; then
+            log info "The image $image_name is not found, Pulling from docker..."
             try \
-                "docker pull $i" \
+                "docker pull $image_name" \
                 throw \
-                "An error occured while pulling the image $i"
-            overwrite "The image $i is not found, Pulling from docker... Done"
+                "An error occured while pulling the image $image_name"
+
+            overwrite "The image $image_name is not found, Pulling from docker... Done"
         fi
     done
 }
@@ -303,8 +304,8 @@ docker::deploy_sanity() {
         exit 1
     fi
 
-    for i in "$@"; do
-        docker::await_container_status "$i" "Running"
+    for service_name in "$@"; do
+        docker::await_container_status "$service_name" "Running"
     done
 }
 


### PR DESCRIPTION
In this PR, I added a function that will prompt a warning if the service will have the status "Preparation" for 3minutes. This status is taking more than 3 minutes usually because the image doesn't exit or it is not updated. 

![image](https://user-images.githubusercontent.com/48720958/208134360-2b1936db-f7e1-42ac-8843-edc2459c3618.png)

Please give me your opinion, I can remove it if you think it is useless 

Also I added a check on the images existence, if they exist nothing happens, if they don't, they will be pulled before the deployment

![image](https://user-images.githubusercontent.com/48720958/208129207-14b038aa-761c-42d3-9eb2-4fcabd39bbe8.png)

In case the pulling fails for network issues: 
![image](https://user-images.githubusercontent.com/48720958/208129287-2ae2cdeb-822d-4e11-93ea-b44ec9b58fe9.png)


