### PR TITLE
Add fix to copy of docker daemon for new ansible version

### DIFF
--- a/infrastructure/ansible/roles/docker/tasks/main.yml
+++ b/infrastructure/ansible/roles/docker/tasks/main.yml
@@ -87,6 +87,9 @@
     password: '{{ docker_password }}'
     state: present
 
+- name: create docker daemon config path if it doesn't exist
+  raw: sudo mkdir -p /etc/docker
+
 - name: configure docker logs rotation
   copy:
     src: docker-daemon.json


### PR DESCRIPTION
To fix the copy command by creating the directory first. This only became an issue due to upgrading ansible