### PR TITLE
perf: disable unused features in hapi

### DIFF
--- a/fhir-datastore-hapi-fhir/docker-compose.yml
+++ b/fhir-datastore-hapi-fhir/docker-compose.yml
@@ -21,6 +21,13 @@ services:
       - hapi.fhir.bulk_export_enabled=true
       - hapi.fhir.enable_repository_validating_interceptor=true
       - hapi.fhir.fhir_version=${FHIR_VERSION}
+      - hapi.fhir.advanced_lucene_indexing=false
+      - hapi.fhir.mdm_enabled=false
+      - hapi.fhir.subscription.resthook_enabled=false
+      - hapi.fhir.cql_enabled=false
+      - hapi.fhir.default_pretty_print=false
+      - hapi.fhir.graphql_enabled=false
+      - hapi.fhir.narrative_enabled=false
       - JAVA_TOOL_OPTIONS=${HF_JAVA_OPTS}
       - CATALINA_OPTS=${HF_JAVA_OPTS}
     deploy:


### PR DESCRIPTION
Disable featues in default hapi fhir instance, the narrative generation being the most consuming process : 
     - hapi.fhir.advanced_lucene_indexing=false
      - hapi.fhir.mdm_enabled=false
      - hapi.fhir.subscription.resthook_enabled=false
      - hapi.fhir.cql_enabled=false
      - hapi.fhir.default_pretty_print=false
      - hapi.fhir.graphql_enabled=false
      - hapi.fhir.narrative_enabled=false

This would lead to a increase of 30% in performance.