### PR TITLE
Set the mongo replication config in single node

### DIFF
--- a/interoperability-layer-openhim/swarm.sh
+++ b/interoperability-layer-openhim/swarm.sh
@@ -57,7 +57,7 @@ function initialize_package() {
       else
         config::await_service_running "mongo-1" "${COMPOSE_FILE_PATH}"/docker-compose.await-helper-mongo.yml "1" "$STACK"
 
-        try "docker exec -i $(docker ps -q -f name=openhim_mongo) mongo --eval \"rs.initiate()\"" throw "Could not initiate replica set for the single mongo instance. Some services use \
+        try "docker exec -i $(docker ps -q -f name=openhim_mongo) mongo --eval \"rs.initiate({'_id': 'mongo-set','members': [{'_id': 0,'priority': 1,'host': 'mongo-1:27017'}]})\"" throw "Could not initiate replica set for the single mongo instance. Some services use \
         mongo event listeners which only work with a replica set"
       fi
     fi


### PR DESCRIPTION
This is so the host is specified and when the mongo service dies and is restored, the running node will always be the primary node, ensuring that we always have read and write access