### PR TITLE
Add IPS env variables for Hapi FHIR

### DIFF
--- a/fhir-datastore-hapi-fhir/docker-compose.yml
+++ b/fhir-datastore-hapi-fhir/docker-compose.yml
@@ -20,6 +20,9 @@ services:
       - hapi.fhir.allow_external_references=true
       - hapi.fhir.bulk_export_enabled=true
       - hapi.fhir.ips_enabled=${IPS_ENABLED}
+      - hapi.fhir.implementationguides.ips_1_0_0.url=${IPS_URL}
+      - hapi.fhir.implementationguides.ips_1_0_0.name=${IPS_NAME}
+      - hapi.fhir.implementationguides.ips_1_0_0.version=${IPS_VERSION}
       - hapi.fhir.ig_runtime_upload_enabled=${ENABLE_RUNTIME_IG_UPLOAD}
       - hapi.fhir.enable_repository_validating_interceptor=true
       - hapi.fhir.fhir_version=${FHIR_VERSION}


### PR DESCRIPTION
To configure the required IPS modules inside of Hapi FHIR

Eg: docker service update hapi-fhir_hapi-fhir --image jembi/hapi:v6.10.1-wget --env-add=hapi.fhir.ips_enabled=true --env-add=hapi.fhir.implementationguides.ips_1_0_0.url=https://hl7.org/fhir/uv/ips/package.tgz  --env-add=hapi.fhir.implementationguides.ips_1_0_0.name=hl7.fhir.uv.ips --env-add=hapi.fhir.implementationguides.ips_1_0_0.version=1.0.0