### PR TITLE
EHN-36: Add an attachable network to clickhouse for the dbt ofelia job

### DIFF
--- a/analytics-datastore-clickhouse/docker-compose.cluster.yml
+++ b/analytics-datastore-clickhouse/docker-compose.cluster.yml
@@ -25,6 +25,7 @@ services:
         source: clickhouse_use_keeper.xml
     networks:
       public:
+      dbt:
       default:
 
   analytics-datastore-clickhouse-02:

--- a/analytics-datastore-clickhouse/docker-compose.yml
+++ b/analytics-datastore-clickhouse/docker-compose.yml
@@ -9,6 +9,7 @@ services:
       - clickhouse-data:/var/lib/clickhouse/
     networks:
       public:
+      dbt:
       default:
 
 volumes:
@@ -18,4 +19,8 @@ networks:
   public:
     name: clickhouse_public
     external: true
+  dbt:
+    name: dbt_attachable
+    external: true
+    attachable: true
   default:


### PR DESCRIPTION
The ofelia codebase, as of this writing, does not support environment variables for service-run job types. This then forces us to create an attachable network, since a container cannot attach to a non-attachable network (unlike services which can).

As such this PR is necessary in order for https://github.com/jembi/ethiopia-ndr/pull/13 to function.