### PR TITLE
TB-412: Add table config override to set ttl for system log tables

### DIFF
--- a/analytics-datastore-clickhouse/docker-compose.cluster.yml
+++ b/analytics-datastore-clickhouse/docker-compose.cluster.yml
@@ -23,6 +23,14 @@ services:
         source: clickhouse_remote_servers.xml
       - target: /etc/clickhouse-server/config.d/use_keeper.xml
         source: clickhouse_use_keeper.xml
+      - target: /etc/clickhouse-server/config.d/metric_log.xml
+        source: clickhouse_metric_log.xml
+      - target: /etc/clickhouse-server/config.d/part_log.xml
+        source: clickhouse_part_log.xml
+      - target: /etc/clickhouse-server/config.d/query_log.xml
+        source: clickhouse_query_log.xml
+      - target: /etc/clickhouse-server/config.d/trace_log.xml
+        source: clickhouse_trace_log.xml
     networks:
       public:
       default:
@@ -49,6 +57,14 @@ services:
         source: clickhouse_remote_servers.xml
       - target: /etc/clickhouse-server/config.d/use_keeper.xml
         source: clickhouse_use_keeper.xml
+      - target: /etc/clickhouse-server/config.d/metric_log.xml
+        source: clickhouse_metric_log.xml
+      - target: /etc/clickhouse-server/config.d/part_log.xml
+        source: clickhouse_part_log.xml
+      - target: /etc/clickhouse-server/config.d/query_log.xml
+        source: clickhouse_query_log.xml
+      - target: /etc/clickhouse-server/config.d/trace_log.xml
+        source: clickhouse_trace_log.xml
     networks:
       public:
       default:
@@ -75,6 +91,14 @@ services:
         source: clickhouse_remote_servers.xml
       - target: /etc/clickhouse-server/config.d/use_keeper.xml
         source: clickhouse_use_keeper.xml
+      - target: /etc/clickhouse-server/config.d/metric_log.xml
+        source: clickhouse_metric_log.xml
+      - target: /etc/clickhouse-server/config.d/part_log.xml
+        source: clickhouse_part_log.xml
+      - target: /etc/clickhouse-server/config.d/query_log.xml
+        source: clickhouse_query_log.xml
+      - target: /etc/clickhouse-server/config.d/trace_log.xml
+        source: clickhouse_trace_log.xml
     networks:
       public:
       default:
@@ -95,6 +119,14 @@ services:
         source: clickhouse_remote_servers.xml
       - target: /etc/clickhouse-server/config.d/use_keeper.xml
         source: clickhouse_use_keeper.xml
+      - target: /etc/clickhouse-server/config.d/metric_log.xml
+        source: clickhouse_metric_log.xml
+      - target: /etc/clickhouse-server/config.d/part_log.xml
+        source: clickhouse_part_log.xml
+      - target: /etc/clickhouse-server/config.d/query_log.xml
+        source: clickhouse_query_log.xml
+      - target: /etc/clickhouse-server/config.d/trace_log.xml
+        source: clickhouse_trace_log.xml
     networks:
       public:
       default:
@@ -154,6 +186,26 @@ configs:
   clickhouse_use_keeper.xml:
     file: ./cluster_configs/use_keeper.xml
     name: use_keeper.xml-${use_keeper_xml_DIGEST:?err}
+    labels: 
+      name: clickhouse
+  clickhouse_metric_log.xml:
+    file: ./general_configs/metric_log.xml
+    name: metric_log.xml.xml-${metric_log_xml_DIGEST:?err}
+    labels: 
+      name: clickhouse
+  clickhouse_part_log.xml:
+    file: ./general_configs/part_log.xml
+    name: part_log.xml.xml-${part_log_xml_DIGEST:?err}
+    labels: 
+      name: clickhouse
+  clickhouse_query_log.xml:
+    file: ./general_configs/query_log.xml
+    name: query_log.xml.xml-${query_log_xml_DIGEST:?err}
+    labels: 
+      name: clickhouse
+  clickhouse_trace_log.xml:
+    file: ./general_configs/trace_log.xml
+    name: trace_log.xml.xml-${trace_log_xml_DIGEST:?err}
     labels: 
       name: clickhouse
 

--- a/analytics-datastore-clickhouse/docker-compose.yml
+++ b/analytics-datastore-clickhouse/docker-compose.yml
@@ -7,12 +7,43 @@ services:
       noFile: 262144
     volumes:
       - clickhouse-data:/var/lib/clickhouse/
+    configs:
+      - target: /etc/clickhouse-server/config.d/metric_log.xml
+        source: clickhouse_metric_log.xml
+      - target: /etc/clickhouse-server/config.d/part_log.xml
+        source: clickhouse_part_log.xml
+      - target: /etc/clickhouse-server/config.d/query_log.xml
+        source: clickhouse_query_log.xml
+      - target: /etc/clickhouse-server/config.d/trace_log.xml
+        source: clickhouse_trace_log.xml  
     networks:
       public:
       default:
 
 volumes:
   clickhouse-data:
+
+configs:
+  clickhouse_metric_log.xml:
+    file: ./general_configs/metric_log.xml
+    name: metric_log.xml.xml-${metric_log_xml_DIGEST:?err}
+    labels: 
+      name: clickhouse
+  clickhouse_part_log.xml:
+    file: ./general_configs/part_log.xml
+    name: part_log.xml.xml-${part_log_xml_DIGEST:?err}
+    labels: 
+      name: clickhouse
+  clickhouse_query_log.xml:
+    file: ./general_configs/query_log.xml
+    name: query_log.xml.xml-${query_log_xml_DIGEST:?err}
+    labels: 
+      name: clickhouse
+  clickhouse_trace_log.xml:
+    file: ./general_configs/trace_log.xml
+    name: trace_log.xml.xml-${trace_log_xml_DIGEST:?err}
+    labels: 
+      name: clickhouse
 
 networks:
   public:

--- a/analytics-datastore-clickhouse/general_configs/metric_log.xml
+++ b/analytics-datastore-clickhouse/general_configs/metric_log.xml
@@ -1,0 +1,5 @@
+<clickhouse>
+    <metric_log>
+        <ttl>event_date + INTERVAL 30 DAY DELETE</ttl>
+    </metric_log>
+</clickhouse>

--- a/analytics-datastore-clickhouse/general_configs/part_log.xml
+++ b/analytics-datastore-clickhouse/general_configs/part_log.xml
@@ -1,0 +1,5 @@
+<clickhouse>
+    <part_log>
+        <ttl>event_date + INTERVAL 30 DAY DELETE</ttl>
+    </part_log>
+</clickhouse>

--- a/analytics-datastore-clickhouse/general_configs/query_log.xml
+++ b/analytics-datastore-clickhouse/general_configs/query_log.xml
@@ -1,0 +1,5 @@
+<clickhouse>
+    <query_log>
+        <ttl>event_date + INTERVAL 30 DAY DELETE</ttl>
+    </query_log>
+</clickhouse>

--- a/analytics-datastore-clickhouse/general_configs/trace_log.xml
+++ b/analytics-datastore-clickhouse/general_configs/trace_log.xml
@@ -1,0 +1,5 @@
+<clickhouse>
+    <trace_log>
+        <ttl>event_date + INTERVAL 30 DAY DELETE</ttl>
+    </trace_log>
+</clickhouse>


### PR DESCRIPTION
Investigating QA clickhouse table sizes lead us to find that the one system table is responsible for just under 500GB worth of data. 
![image](https://github.com/jembi/platform/assets/125864621/2c0cacf2-06f9-4a1d-aa80-fdf425ccc0df)

When querying clickhouse for the corresponding table for that GUID we find that it is the `system.part_log`
![image](https://github.com/jembi/platform/assets/125864621/21e4393d-e514-455f-857b-f74b7fa8699e)

By default clickhouse does not enforce a retention period / TTL on system tables and so these grow to infinity.

As such this PR is here to set a retention period of 30 days for most of the system log related tables.