### PR TITLE
Allow configuration for Prometheus data retention

### DIFF
--- a/monitoring/docker-compose.yml
+++ b/monitoring/docker-compose.yml
@@ -76,6 +76,7 @@ services:
       - '--web.console.libraries=/etc/prometheus/console_libraries'
       - '--web.console.templates=/etc/prometheus/consoles'
       - '--web.enable-lifecycle'
+      - '--storage.tsdb.retention.time=${MO_RETENTION_TIME}'
     networks:
       public:
       default:

--- a/monitoring/package-metadata.json
+++ b/monitoring/package-metadata.json
@@ -21,6 +21,7 @@
     "KC_GRAFANA_ROOT_URL": "http://localhost:3000",
     "GF_SERVER_DOMAIN": "localhost",
     "MO_SECURITY_ADMIN_USER": "admin",
-    "MO_SECURITY_ADMIN_PASSWORD": "dev_password_only"
+    "MO_SECURITY_ADMIN_PASSWORD": "dev_password_only",
+    "MO_RETENTION_TIME": "15d"
   }
 }


### PR DESCRIPTION
The default data retention for Prometheus was being applied and there wasnt any way to configure this. The current change allows an env to be supplied to override the default data retention (1m/6m/365d/1y etc)

![image](https://github.com/jembi/platform/assets/7311421/cd9d81e9-4de4-4bba-8ee7-07edec14f4a8)

CU_86by5fqb3