### PR TITLE
Update package base to latest version - deployment speed boost!

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM openhie/package-base:2.2.0
+FROM openhie/package-base:2.3.1
 
 # Install yq
 RUN curl -L https://github.com/mikefarah/yq/releases/download/v4.23.1/yq_linux_amd64 -o /usr/bin/yq


### PR DESCRIPTION
This is allow us to use the concurrency feature which will massively speed up deployments!

By default concurrently of 5 will be used if you want to change this you need to download the latest version of the instant CLI (v2.3.1) and supply the `--concurrency` flag with a number when performing a package action.