### PR TITLE
Fix get-cli.sh script to point to correct windows assest

### DIFF
--- a/get-cli.sh
+++ b/get-cli.sh
@@ -6,27 +6,27 @@ cli_version=${2:-latest}
 case ${option} in
 linux)
   echo "Downloading linux binary version: ${cli_version}"
-  curl -L https://github.com/openhie/package-starter-kit/releases/download/"$cli_version"/instant-linux -o instant-linux
+  curl -L https://github.com/openhie/instant-v2/releases/download/"$cli_version"/instant-linux -o instant-linux
   chmod +x ./instant-linux
   exit 0
   ;;
 macos)
   echo "Downloading macos binary version: ${cli_version}"
-  curl -L https://github.com/openhie/package-starter-kit/releases/download/"$cli_version"/instant-macos -o instant-macos
+  curl -L https://github.com/openhie/instant-v2/releases/download/"$cli_version"/instant-macos -o instant-macos
   chmod +x ./instant-macos
   exit 0
   ;;
 windows)
   echo "Downloading windows binary version: ${cli_version}"
-  curl -L https://github.com/openhie/package-starter-kit/releases/download/"$cli_version"/instant-win.exe -o instant.exe
+  curl -L https://github.com/openhie/instant-v2/releases/download/"$cli_version"/instant-win.exe -o instant.exe
   chmod +x ./instant.exe
   exit 0
   ;;
 all)
   echo "Downloading all binaries, version: ${cli_version}"
-  curl -L https://github.com/openhie/package-starter-kit/releases/download/"$cli_version"/instant-linux -o instant-linux
-  curl -L https://github.com/openhie/package-starter-kit/releases/download/"$cli_version"/instant-macos -o instant-macos
-  curl -L https://github.com/openhie/package-starter-kit/releases/download/"$cli_version"/instant-win.exe -o instant.exe
+  curl -L https://github.com/openhie/instant-v2/releases/download/"$cli_version"/instant-linux -o instant-linux
+  curl -L https://github.com/openhie/instant-v2/releases/download/"$cli_version"/instant-macos -o instant-macos
+  curl -L https://github.com/openhie/instant-v2/releases/download/"$cli_version"/instant-win.exe -o instant.exe
   chmod +x ./instant-linux
   chmod +x ./instant-macos
   chmod +x ./instant.exe

--- a/get-cli.sh
+++ b/get-cli.sh
@@ -18,7 +18,7 @@ macos)
   ;;
 windows)
   echo "Downloading windows binary version: ${cli_version}"
-  curl -L https://github.com/openhie/package-starter-kit/releases/download/"$cli_version"/instant.exe -o instant.exe
+  curl -L https://github.com/openhie/package-starter-kit/releases/download/"$cli_version"/instant-win.exe -o instant.exe
   chmod +x ./instant.exe
   exit 0
   ;;
@@ -26,7 +26,7 @@ all)
   echo "Downloading all binaries, version: ${cli_version}"
   curl -L https://github.com/openhie/package-starter-kit/releases/download/"$cli_version"/instant-linux -o instant-linux
   curl -L https://github.com/openhie/package-starter-kit/releases/download/"$cli_version"/instant-macos -o instant-macos
-  curl -L https://github.com/openhie/package-starter-kit/releases/download/"$cli_version"/instant.exe -o instant.exe
+  curl -L https://github.com/openhie/package-starter-kit/releases/download/"$cli_version"/instant-win.exe -o instant.exe
   chmod +x ./instant-linux
   chmod +x ./instant-macos
   chmod +x ./instant.exe


### PR DESCRIPTION
The get-cli.sh script was pointing to an incorrect windows assets, and was never updating/downloading the windows version correctly.

https://github.com/openhie/instant-v2/releases/
https://github.com/openhie/instant-v2/releases/download/2.3.1/instant-win.exe