### PR TITLE
Do not initiate replicaset in single mode

### DIFF
--- a/interoperability-layer-openhim/docker-compose-mongo.yml
+++ b/interoperability-layer-openhim/docker-compose-mongo.yml
@@ -3,7 +3,6 @@ version: "3.9"
 services:
   mongo-1:
     image: mongo:4.2
-    command: ['--replSet', 'mongo-set', '--wiredTigerCacheSizeGB', '0.5']
     volumes:
       - "openhim-mongo-01:/data/db"
       - "openhim-mongo-01-config:/data/configdb"


### PR DESCRIPTION
I run into the following issue with platform latest in single mode :

winston-mongodb, initialization error:  MongoError: not master
openhim_openhim-core.1.kzg8ompgvvh4@docker-desktop    |     at Connection.<anonymous> (/app/node_modules/winston-mongodb/node_modules/mongodb/lib/core/connection/pool.js:453:61)
openhim_openhim-core.1.kzg8ompgvvh4@docker-desktop    |     at Connection.emit (events.js:400:28)
openhim_openhim-core.1.kzg8ompgvvh4@docker-desktop    |     at processMessage (/app/node_modules/winston-mongodb/node_modules/mongodb/lib/core/connection/connection.js:456:10)
openhim_openhim-core.1.kzg8ompgvvh4@docker-desktop    |     at Socket.<anonymous> (/app/node_modules/winston-mongodb/node_modules/mongodb/lib/core/connection/connection.js:625:15)
openhim_openhim-core.1.kzg8ompgvvh4@docker-desktop    |     at Socket.emit (events.js:400:28)
openhim_openhim-core.1.kzg8ompgvvh4@docker-desktop    |     at addChunk (internal/streams/readable.js:293:12)
openhim_openhim-core.1.kzg8ompgvvh4@docker-desktop    |     at readableAddChunk (internal/streams/readable.js:267:9)
openhim_openhim-core.1.kzg8ompgvvh4@docker-desktop    |     at Socket.Readable.push (internal/streams/readable.js:206:10)
openhim_openhim-core.1.kzg8ompgvvh4@docker-desktop    |     at TCP.onStreamRead (internal/stream_base_commons.js:188:23) {
openhim_openhim-core.1.kzg8ompgvvh4@docker-desktop    |   ok: 0,
openhim_openhim-core.1.kzg8ompgvvh4@docker-desktop    |   code: 10107,
openhim_openhim-core.1.kzg8ompgvvh4@docker-desktop    |   codeName: 'NotWritablePrimary'
openhim_openhim-core.1.kzg8ompgvvh4@docker-desktop    | }

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Simplified the MongoDB service configuration for better maintainability. No impact on end-user functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->