### PR TITLE
Dynamically define Kibana image tag to use

### DIFF
--- a/dashboard-visualiser-kibana/docker-compose.yml
+++ b/dashboard-visualiser-kibana/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.9'
 
 services:
   dashboard-visualiser-kibana:
-    image: docker.elastic.co/kibana/kibana:7.13.0
+    image: docker.elastic.co/kibana/kibana:${KIBANA_IMAGE_TAG}
     healthcheck:
       test: curl --fail http://localhost:5601 || exit 1
       interval: 10s

--- a/dashboard-visualiser-kibana/package-metadata.json
+++ b/dashboard-visualiser-kibana/package-metadata.json
@@ -6,6 +6,7 @@
   "version": "0.0.1",
   "dependencies": ["analytics-datastore-elastic-search"],
   "environmentVariables": {
+    "KIBANA_IMAGE_TAG": "7.13.0",
     "KIBANA_INSTANCES": 1,
     "ES_LEADER_NODE": "analytics-datastore-elastic-search",
     "ES_KIBANA_SYSTEM": "dev_password_only",


### PR DESCRIPTION
To allow this to be configurable based on project needs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced the ability to dynamically set the Kibana image version using the `KIBANA_IMAGE_TAG` environment variable.

- **Configuration**
  - Updated the Kibana image configuration to use a variable for the version, enhancing flexibility and ease of updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->