### PR TITLE
feat: Update docker-compose.yml files for reverse proxy and services

### DIFF
--- a/fhir-ig-importer/docker-compose.yml
+++ b/fhir-ig-importer/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3.9'
+version: "3.9"
 
 services:
   fhir-ig-importer-mediator:
@@ -18,6 +18,7 @@ services:
     networks:
       hapi-fhir:
       openhim:
+      reverse-proxy:
     environment:
       FHIR_IG_IMPORTER_CORE_URL: ${FHIR_IG_IMPORTER_CORE_URL}
 
@@ -28,5 +29,7 @@ networks:
   openhim:
     name: openhim_public
     external: true
+  reverse-proxy:
+    name: reverse-proxy_public
+    external: true
   default:
-  

--- a/kafka-mapper-consumer/docker-compose.yml
+++ b/kafka-mapper-consumer/docker-compose.yml
@@ -27,6 +27,7 @@ services:
     image: ${KAFKA_CONSUMER_MAPPER_UI_VERSION}
     networks:
       kafka:
+      reverse-proxy:
 
 configs:
   fhir-mapping.json:
@@ -44,5 +45,8 @@ networks:
     external: true
   openhim:
     name: openhim_public
+    external: true
+  reverse-proxy:
+    name: reverse-proxy_public
     external: true
   default:

--- a/reprocess-mediator/docker-compose.yml
+++ b/reprocess-mediator/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3.9'
+version: "3.9"
 
 services:
   reprocess-mediator:
@@ -12,12 +12,13 @@ services:
       OPENHIM_USERNAME: ${OPENHIM_USERNAME}
       OPENHIM_PASSWORD: ${OPENHIM_PASSWORD}
       REGISTER_MEDIATOR: ${REGISTER_MEDIATOR}
-  
+
   reprocess-mediator-ui:
     image: ${REPROCESS_MEDIATOR_UI_VERSION}
     networks:
       openhim:
       reprocess:
+      reverse-proxy:
     environment:
       REPROCESSOR_API_BASE_URL: ${REPROCESSOR_API_BASE_URL}
 
@@ -28,4 +29,6 @@ networks:
   reprocess:
     name: reprocess_public
     external: true
-
+  reverse-proxy:
+    name: reverse-proxy_public
+    external: true

--- a/reverse-proxy-nginx/package-conf-insecure/http-openhim-insecure.conf
+++ b/reverse-proxy-nginx/package-conf-insecure/http-openhim-insecure.conf
@@ -14,6 +14,24 @@ server {
 server {
     listen                80;
 
+    location /fhir-ig-importer {
+        resolver          127.0.0.11 valid=30s;
+        set               $upstream_fhir_ig_importer_ui fhir-ig-importer-ui;
+        proxy_pass        http://$upstream_fhir_ig_importer_ui:8080/jembi-fhir-ig-importer.js;
+    }
+
+    location /kafka-mapper-consumer-ui {
+        resolver          127.0.0.11 valid=30s;
+        set               $upstream_kafka_consumer_mapper_ui kafka-mapper-consumer-ui;
+        proxy_pass        http://$upstream_kafka_consumer_mapper_ui:80/jembi-kafka-mapper-consumer-ui.js;
+    }
+
+    location /reprocess-mediator-ui {
+        resolver          127.0.0.11 valid=30s;
+        set               $upstream_reprocess_mediator_ui reprocess-mediator-ui;
+        proxy_pass        http://$upstream_reprocess_mediator_ui:80/jembi-reprocessor-mediator-microfrontend.js;
+    }
+
     location / {
         resolver          127.0.0.11 valid=30s;
         set               $upstream_openhim_console openhim-console;

--- a/reverse-proxy-nginx/package-conf-secure/http-openhim-secure.conf
+++ b/reverse-proxy-nginx/package-conf-secure/http-openhim-secure.conf
@@ -85,6 +85,24 @@ server {
     listen                [::]:443 ssl;
     server_name           openhimconsole.*;
 
+    location /fhir-ig-importer {
+        resolver          127.0.0.11 valid=30s;
+        set               $upstream_fhir_ig_importer_ui fhir-ig-importer-ui;
+        proxy_pass        http://$upstream_fhir_ig_importer_ui:8080/jembi-fhir-ig-importer.js;
+    }
+
+    location /kafka-mapper-consumer-ui {
+        resolver          127.0.0.11 valid=30s;
+        set               $upstream_kafka_consumer_mapper_ui kafka-mapper-consumer-ui;
+        proxy_pass        http://$upstream_kafka_consumer_mapper_ui:80/jembi-kafka-mapper-consumer-ui.js;
+    }
+
+    location /reprocess-mediator-ui {
+        resolver          127.0.0.11 valid=30s;
+        set               $upstream_reprocess_mediator_ui reprocess-mediator-ui;
+        proxy_pass        http://$upstream_reprocess_mediator_ui:80/jembi-reprocessor-mediator-microfrontend.js;
+    }
+
     location /.well-known/acme-challenge/ {
         resolver          127.0.0.11 valid=30s;
         set               $upstream_certbot certbot;


### PR DESCRIPTION
The docker-compose.yml files for the reverse proxy and services have been updated to include the necessary configurations for the reverse proxy. This will enable routing of requests to the appropriate microfrontend UIs for the fhir-ig-importer, kafka-mapper-consumer, and reprocess-mediator services.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced reverse proxy configurations for `fhir-ig-importer`, `kafka-mapper-consumer`, and `reprocess-mediator` services to enhance network routing and security.
  - Added new proxy paths for the mentioned services in both secure and insecure Nginx configuration files.

- **Improvements**
  - Updated Docker Compose files to use double quotes for version key consistency.
  - Added new network configurations to support reverse proxy setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->