### PR TITLE
upgrade adaptor version project.yaml

### DIFF
--- a/openfn/importer/workflows/example/project.yaml
+++ b/openfn/importer/workflows/example/project.yaml
@@ -113,7 +113,7 @@ workflows:
 
       map-encounters:
         name: map encounters
-        adaptor: "@openfn/language-fhir-jembi@0.0.18"
+        adaptor: "@openfn/language-fhir-ndr-et@0.1.0"
         credential: null
         body: |
           fn(state => {
@@ -200,7 +200,7 @@ workflows:
 
       map-patients:
         name: map patients
-        adaptor: "@openfn/language-fhir-jembi@0.0.18"
+        adaptor: "@openfn/language-fhir-ndr-et@0.1.0"
         credential: null
         body: |
           // Handle patients (and related persons)
@@ -588,7 +588,7 @@ workflows:
 
       map-medications:
         name: map medications
-        adaptor: "@openfn/language-fhir-jembi@0.0.18"
+        adaptor: "@openfn/language-fhir-ndr-et@0.1.0"
         credential: null
         body: |
           const createId = (base, type) => {
@@ -1208,7 +1208,7 @@ workflows:
 
       build-bundle:
         name: build bundle
-        adaptor: "@openfn/language-fhir-jembi@0.0.18"
+        adaptor: "@openfn/language-common@2.0.1"
         credential: null
         body: |
           const wrapResource = (res) => {


### PR DESCRIPTION
@drizzentic if you merge this and pull this `project.yaml` file to update your local workflow config, this will ensure your local workflow is using the latest adaptor version: `fhir-ndr-et@0.1.0`. If looks like this adaptor `fhir-ndr-et` is not available in your local openfn instance, you can pull again from the lightning docker image (2.9.5).
<img width="260" alt="Screenshot 2024-09-27 at 5 04 15 PM" src="https://github.com/user-attachments/assets/d924f12c-901a-43b8-877b-ebb44fffe062">


This is not a critical update, but it will introduce two changes: 
1. The adaptor was renamed from `fhir-jembi` to `fhir-ndr-et` to better match this project (fyi [see adaptor docs](https://docs.openfn.org/adaptors/packages/fhir-ndr-et-docs))
2. A minor change was implemented to ensure that `text` values associated with codes are outputted in the payloads processed by the openfn workflow. The requests to the NDR FHIR api were succeeding even without this in our tests, but it will ensure the mapped CDR payloads match 100% with the NDR examples and spec. 

```
 "code" : {
    "coding" : [
      {
        "system" : ""http://loinc.org",
        "code" : ""85658-3"
      }
    ],
    "text" : "Occupation" //missing from payloads on the last adaptor version
  },"
  ```

 