### PR TITLE
prevent port conflict between prometheus and datalake

### DIFF
--- a/datalake/docker-compose.dev.yml
+++ b/datalake/docker-compose.dev.yml
@@ -8,5 +8,5 @@ services:
         mode: host
 
       - target: 9090
-        published: 9090
+        published: 9393
         mode: host

--- a/datalake/docker-compose.yml
+++ b/datalake/docker-compose.yml
@@ -4,7 +4,7 @@ services:
   minio-01:
     image: ${MINIO_IMAGE}
     entrypoint: sh
-    command: c 'mkdir -p /data1/loki /data2/loki && minio server --console-address ":9001" --address ":9090" http://minio-0{1...${NUM_MINIO_SERVERS}}/data{1...2}'
+    command: -c 'mkdir -p /data1/loki /data2/loki && minio server --console-address ":9001" --address ":9090" http://minio-0{1..${NUM_MINIO_SERVERS}}/data{1..2}'
     environment:
       MINIO_ROOT_USER: ${MO_SECURITY_ADMIN_USER}
       MINIO_ROOT_PASSWORD: ${MO_SECURITY_ADMIN_PASSWORD}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated port configuration for the MinIO service, changing the published port from 9090 to 9393.
	- Modified the command syntax for the MinIO service to ensure correct server instance creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->